### PR TITLE
Добавил страницу для прототипирования

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "scripts": {
     "start": "parcel src/index.html --out-dir=tmp",
+    "start:prototype": "parcel src/prototype.html --out-dir=tmp",
     "build": "parcel build src/index.html --out-dir=dist --public-url='./'"
   },
   "keywords": [],

--- a/src/assets/styles/index.scss
+++ b/src/assets/styles/index.scss
@@ -16,6 +16,14 @@ h4 {
   margin: 0;
 }
 
+.aligned-container {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px;
+}
+
 button {
   padding: 0;
   border: none;

--- a/src/prototype.html
+++ b/src/prototype.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link
+      href="//db.onlinewebfonts.com/c/65049e8b2a3ba8f203faebf5b0609f7f?family=San+Francisco+Display"
+      rel="stylesheet"
+      type="text/css"
+    />
+    <title>netguru:prototype</title>
+  </head>
+
+  <body class="aligned-container">
+      <div id="place-content-here"></div>
+    <script src="assets/scripts/index.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
Добавил страницу `prototype.html` для прототипирования. 
Клади UI-элементы в контейнер с id `place-content-here` и работай изолированно. 

Чтобы начать работать в режиме прототипирования нужно пользоваться командой `npm run start:prototype` вместо `npm run start`. 
